### PR TITLE
use env in hashbang line instead of explicit path to php

### DIFF
--- a/documentation.php
+++ b/documentation.php
@@ -6,7 +6,7 @@
 <style>
    #main { margin: 0 10% 0 5% }
    ol { list-style: decimal; }
-   ol.sublist { list-style: lower-latin; } 
+   ol.sublist { list-style: lower-latin; }
 table td {padding-right: 2em;  }
 </style>
 </head>
@@ -46,8 +46,6 @@ table td {padding-right: 2em;  }
    <code>&gt; chgrp apache prepped/</code><br />
 </div>
 where "apache" is the name of a permissions group that grants write-permissions to the web server and includes the user who sets up the cron job in the next step.</li>
-									 <li>Make sure the two files <b>prep_file.php</b> and <b>innreach_check.php</b> begin with valid pointers to where PHP is running on your server. By default, they will start with this declaration: <b>#!/usr/bin/php</b> -- that will work on many servers, but not all. To find a valid php path, type on the command line <b>which php</b></li>
-
    <li>Set up the <code>cron</code> jobs that power Weeding Helper&apos;s automated functions. Cron is a unix utility that can run scripts on a regular basis; if you hare unfamiliar with cron, you will want to get help from a system administrator or similar. The two files that will need to be activated by cron jobs are <b>prep_file.php</b> and <b>innreach_check.php</b>. Running the cronjobs once per minute is an effective approach.
    <ol class="sublist">
    <li><b>prep_file.php</b> takes an already-uploaded file loads it into the database. That only needs to happen once per file. If that cron job runs once per minute, it will usually not need to do anything; but when a file is uploaded, it will reliably be added to the database very quickly.</li>
@@ -55,7 +53,7 @@ where "apache" is the name of a permissions group that grants write-permissions 
 </ol>
 
 																																																																											<p>Example of a crontab file; your path may vary:
-<div class="example">	      
+<div class="example">
 <pre><code>
 #|      |       |       |       |       commands
 #|      |       |       |       day of the week (0-6 with 0=Sunday).
@@ -142,7 +140,7 @@ Max field length: none</p>
 <a name="view_edit"></a>
 <h3>View/Edit</h3>
 
-																											The View/Edit function is the meat of Weeding Helper. It uses the AjaxCRUD interface to display selected fields from your data table in an easy-to-read format. With it, you make changes to certain fields -- by default, you may make changes to the "best book", "notes", and "fate" fields. 
+																											The View/Edit function is the meat of Weeding Helper. It uses the AjaxCRUD interface to display selected fields from your data table in an easy-to-read format. With it, you make changes to certain fields -- by default, you may make changes to the "best book", "notes", and "fate" fields.
 <li>"Best book" is intended to indicate whether or not a book is listed in whatever sources your library esteems (e.g. <cite>Books for College Libraries</cite>, subject bibliographies, etc.). It is a Yes/No field.</li>
 																											<li>"Notes" is a free-text field. I use this field most often for notes like "not on shelf", "keep per kri", "last copy", etc. Use it for whatever you like.</li>
 																											<li>"Fate" offers several options you can use to indicate what should happen to a book: weed, de-dup, replace, update, keep.</li>
@@ -156,7 +154,7 @@ Max field length: none</p>
 
 <p>Weeding Helper ships with a set of default settings for what is viewable and editable in the <b>Display Settings</b> function. You can alter the default settings and/or clone the current defaults to apply specific settings to an individual table.</p>
 
-<p>There are two sets of settings: View/Edit Settings and Print Settings. The View/Edit settings specify which fields are <b>visible</b> and/or <b>editable</b> in the View/Edit function. The three settings available for each field are: 
+<p>There are two sets of settings: View/Edit Settings and Print Settings. The View/Edit settings specify which fields are <b>visible</b> and/or <b>editable</b> in the View/Edit function. The three settings available for each field are:
 <li>Display / Editable</li>
 <li>Display / Read-only</li>
 <li>Hide</li>
@@ -164,7 +162,7 @@ Max field length: none</p>
 
 <p>The Print View settings are binary: display on or off.</p>
 
-<hr /> 
+<hr />
 <h2>Credits</h2>
 <a name="main_credits"></a>
 <h3>Main Credits</h3>
@@ -204,7 +202,7 @@ Max field length: none</p>
    <dd>See full license in the sortLC.php file</dd>
    <dd>See also: <a href="http://rocky.uta.edu/doran/sortlc/">http://rocky.uta.edu/doran/sortlc/</a></dd>
 <dd>Ported to PHP by Ken Irwin, kirwin@wittenberg.edu</dd>
-									
+
 <?php  include("attribution.php"); ?>
 
 </div><!-- id=main -->
@@ -212,4 +210,3 @@ Max field length: none</p>
 
 </body>
 </html>
-

--- a/innreach_check.php
+++ b/innreach_check.php
@@ -1,5 +1,5 @@
-#!/usr/bin/php -e
-<?php 
+#!/usr/bin/env php -e
+<?php
 //error_reporting(E_ALL);
 ini_set("memory_limit", "128M");
 ini_set("display_errors", 1);
@@ -8,8 +8,8 @@ include ("mysql_connect.php");
 include ("$path_main/DOM/simple_html_dom.php");
 
 // Frequency: $hits=hits per minute; $sleep = seconds between hits
-if (date("H")<$innreach['night_ends']) { $hits = $innreach['overnight_hits']; } 
-else { 
+if (date("H")<$innreach['night_ends']) { $hits = $innreach['overnight_hits']; }
+else {
   $hits = $innreach['daytime_hits'];
 }
 
@@ -30,13 +30,13 @@ if (mysql_num_rows($r) > 0) { // if there's work to be done
 }
 
 function BatchCheck ($table, $hits, $sleep) {
-  
+
 
   $q = "SELECT * FROM $table WHERE innreach_total_copies IS NULL limit 0,$hits";
   print "$q\n";
 
   $r = mysql_query($q);
-  
+
   if (mysql_num_rows($r) > 0) {
   while ($myrow = mysql_fetch_assoc($r)) {
     extract($myrow);
@@ -57,7 +57,7 @@ function BatchCheck ($table, $hits, $sleep) {
     print "done: $q\n";
   }
 
-  
+
 } //end function BatchCheck
 
 function CheckInnReach($bib, $volume="") {
@@ -114,7 +114,7 @@ function CheckInnReach($bib, $volume="") {
 	$status = $line->find('td', 4);
 	$this_stat = $status->innertext;
 	if (preg_match ("/AVAIL|DUE/", $this_stat)) { $this_stat = "CIRC"; }
-	if ($this_stat != "") 
+	if ($this_stat != "")
 	  $statuses[$this_stat]++;
 	} //end if volume matches or vol=""
       }//end if not the local copy

--- a/prep_file.php
+++ b/prep_file.php
@@ -1,8 +1,8 @@
-#!/usr/bin/php 
-<?php 
+#!/usr/bin/env php 
+<?php
 error_reporting('E_ALL');
 //display_errors(true);
-/* 
+/*
 this script will take a III export and condense the repeatable fields
 (e.g. if there are 3 item records, it will combine the circ data)
 
@@ -11,12 +11,12 @@ change the variables in the setup section below to accomodate different formats
 you'll also have to change the reporting output at the end of the script
 */
 
-include ("scripts.php"); 
+include ("scripts.php");
 include ("sortLC.php");
 include ("config.php");
 require ("mysql_connect.php");
 
-$log = fopen ("log.txt", "a+"); 
+$log = fopen ("log.txt", "a+");
 
 $q = "SELECT * FROM controller WHERE filename != '' and load_date IS NULL";
 $r = mysql_query ($q);
@@ -36,14 +36,14 @@ while ($myrow = mysql_fetch_assoc($r)) {
       if (LoadTable($table_name, $filename)) {
       }
       else { print "FAILED: Cound not load data from $filename into $table_name\n";}
-    } //end if CreateTable 
-    else { 
+    } //end if CreateTable
+    else {
       print "FAILED: Could not create table $table_name\n";
-    } 
+    }
   } //end if PrepFile
   else { print "FAILED: Failed to PrepFile $filename; Database table not created\n"; }
 
-  $q = "SELECT count(*) FROM `$table_name`"; 
+  $q = "SELECT count(*) FROM `$table_name`";
   $r = mysql_query($q);
   $row_a = mysql_fetch_array($r);
   $count = $row_a[0];
@@ -56,14 +56,14 @@ while ($myrow = mysql_fetch_assoc($r)) {
 
 
 
-function PrepFile ($filename) { 
+function PrepFile ($filename) {
   global $path_main;
   /* SETUP VARIABLES */
   $handle = fopen("$path_main/upload/$filename", "r");
   $output_filename = "$path_main/prepped/$filename";
   $output_handle = fopen("$output_filename", "w");
   if (! $output_handle) { return false; }
-  
+
   // these arrays define variable names to be used later
   $fields = array ("author","title","pub","lcsh","cat_date","loc","call_bib","call_item","volume","copy","bcode","mat_type","bib_record","item_record","oclc","total_circ","renews","int_use","last_checkin","barcode");
 
@@ -100,7 +100,7 @@ function PrepFile ($filename) {
 	//otherwise, use the bib_call #
 	if ($call_item != "") { $call = $call_item; }
 	else {$call = $call_bib;}
-	
+
 	$key = "$call v.$volume c.$copy";
 	//	if (! $data[$key]) { $key = "BAD CALL $item_record"; }
 	if ($data[$key] || ($call == "")) {
@@ -118,7 +118,7 @@ function PrepFile ($filename) {
       } //end if not the data headers
     } //end while
     fclose($handle);
-    
+
     //sort and print
     uksort($data, "SortLC");
     foreach($data as $call => $info) {
@@ -183,5 +183,5 @@ function UseLocalInfile () {
 
 
 
-  
+
 ?>


### PR DESCRIPTION
Rather than specify the exact path to PHP in the hashbang line of innreach_check.php and prep_file.php, the `env` utility can locate it in a cross-platform way. So even if PHP is installed in /usr/local, users won't need to update these files with a different path because `env` will find them.

This simplifies set up a bit, allowing the removal of one `<li>` from documentation.php. I see mixed information on the web on whether or not various `env` implementations can pass flags to the target programs, so if the `-e` flag is really necessary in innreach_check.php you'd want to test further or consider not using `env`. I can tell everything works on my OS X laptop but I haven't tested on our Ubuntu servers yet.
