### PR TITLE
Changing author column to contain the RDA-stripped author field, rath…

### DIFF
--- a/scripts.php
+++ b/scripts.php
@@ -328,7 +328,7 @@ function PrepFile ($filename, $call_type="LC") {
       /* strip RDA urls from author and subject fields */
       
       $lcsh = StripRDA($lcsh);
-      $author = StripRDA($lcsh);
+      $author = StripRDA($author);
 
       $key = "";
       if (! preg_match ("/CALL/", $call_item)) {//skip headers


### PR DESCRIPTION
…er than lcsh.

Prior to fix, the RDA-scrubbed subject was being used for both the author and subject field, despite being in the proper sequence in Sierra output file:

![Screen Shot 2019-12-05 at 9 28 15 AM](https://user-images.githubusercontent.com/1636659/70244052-bb3ef580-1741-11ea-9d57-cc417671c75c.png)
.
![Screen Shot 2019-12-05 at 9 26 14 AM](https://user-images.githubusercontent.com/1636659/70243811-51bee700-1741-11ea-819b-5cf5370ea400.png)
